### PR TITLE
Install awscli

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,11 +18,12 @@ script:
 
 
 before_deploy:
-  - mkdir ~/bin
+  - mkdir -p ~/.local/bin
   - wget -O terraform-${TERRAFORM_VERSION}.zip https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip
-  - unzip -d ~/bin terraform-${TERRAFORM_VERSION}.zip
-  - export PATH="~/bin:$PATH"
+  - unzip -d ~/.local/bin terraform-${TERRAFORM_VERSION}.zip
+  - export PATH="~/.local/bin:$PATH"
   - rm terraform-${TERRAFORM_VERSION}.zip
+  - pip install --user `whoami` awscli
 
 deploy:
   provider: script


### PR DESCRIPTION
# Overview
#12 introduced a need for the AWS CLI in order to drive the deployment step. This PR installs the AWS CLI using the method employed [here](https://github.com/rande/travis-kitchensink/blob/48e5915be37a4141dc59a8fd5c06b807c4abbab8/.travis.yml).

# Testing

See https://travis-ci.org/geotrellis/geotrellis-site-deployment/builds/233678997