### PR TITLE
Add VPC module

### DIFF
--- a/scripts/infra
+++ b/scripts/infra
@@ -24,8 +24,6 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
     if [[ -n "${GT_SITE_SETTINGS_BUCKET}" ]]; then
         pushd "${DIR}/../terraform"
 
-        aws s3 cp "s3://${GT_SITE_SETTINGS_BUCKET}/terraform/terraform.tfvars" "${GT_SITE_SETTINGS_BUCKET}.tfvars"
-
         case "${1}" in
             plan)
                 rm -rf .terraform terraform.tfstate*
@@ -33,7 +31,6 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
                           -backend-config="bucket=${GT_SITE_SETTINGS_BUCKET}" \
                           -backend-config="key=terraform/state"
                 terraform plan \
-                          -var-file="${GT_SITE_SETTINGS_BUCKET}.tfvars" \
                           -out="${GT_SITE_SETTINGS_BUCKET}.tfplan"
                 ;;
             apply)

--- a/terraform/container_service.tf
+++ b/terraform/container_service.tf
@@ -12,7 +12,7 @@ data "template_file" "container_instance_cloud_config" {
 module "container_service_cluster" {
   source = "github.com/azavea/terraform-aws-ecs-cluster?ref=0.1.0"
 
-  vpc_id        = "${var.vpc_id}"
+  vpc_id        = "${module.vpc.id}"
   ami_id        = "${var.aws_ecs_ami}"
   instance_type = "${var.container_instance_type}"
   key_name      = "${var.aws_key_name}"
@@ -34,7 +34,7 @@ module "container_service_cluster" {
     "GroupTotalInstances",
   ]
 
-  private_subnet_ids = ["${var.private_subnet_ids}"]
+  private_subnet_ids = "${module.vpc.private_subnet_ids}"
 
   scale_up_cooldown_seconds      = "${var.container_instance_asg_scale_up_cooldown_seconds}"
   scale_down_cooldown_seconds    = "${var.container_instance_asg_scale_down_cooldown_seconds}"

--- a/terraform/dns.tf
+++ b/terraform/dns.tf
@@ -1,0 +1,28 @@
+#
+# Private DNS resources
+#
+resource "aws_route53_zone" "internal" {
+  name       = "${var.r53_private_hosted_zone}"
+  vpc_id     = "${module.vpc.id}"
+  vpc_region = "${var.aws_region}"
+
+  tags {
+    Project     = "${var.project}"
+    Environment = "${var.environment}"
+  }
+}
+
+#
+# Public DNS resources
+#
+resource "aws_route53_zone" "external" {
+  name = "${var.r53_public_hosted_zone}"
+}
+
+resource "aws_route53_record" "bastion" {
+  zone_id = "${aws_route53_zone.external.zone_id}"
+  name    = "bastion.${var.r53_public_hosted_zone}"
+  type    = "CNAME"
+  ttl     = "300"
+  records = ["${module.vpc.bastion_hostname}"]
+}

--- a/terraform/firewall.tf
+++ b/terraform/firewall.tf
@@ -1,4 +1,44 @@
 #
+# Bastion instance security group resources
+#
+
+resource "aws_security_group_rule" "bastion_ssh_ingress" {
+  type              = "ingress"
+  from_port         = 22
+  to_port           = 22
+  protocol          = "tcp"
+  cidr_blocks       = ["${var.vpc_external_access_cidr_block}"]
+  security_group_id = "${module.vpc.bastion_security_group_id}"
+}
+
+resource "aws_security_group_rule" "bastion_ssh_egress" {
+  type              = "egress"
+  from_port         = 22
+  to_port           = 22
+  protocol          = "tcp"
+  cidr_blocks       = ["${module.vpc.cidr_block}"]
+  security_group_id = "${module.vpc.bastion_security_group_id}"
+}
+
+resource "aws_security_group_rule" "bastion_http_egress" {
+  type              = "egress"
+  from_port         = 80
+  to_port           = 80
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = "${module.vpc.bastion_security_group_id}"
+}
+
+resource "aws_security_group_rule" "bastion_https_egress" {
+  type              = "egress"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = "${module.vpc.bastion_security_group_id}"
+}
+
+#
 # Container instance security group resources
 #
 resource "aws_security_group_rule" "container_instance_http_egress" {
@@ -19,4 +59,14 @@ resource "aws_security_group_rule" "container_instance_https_egress" {
   cidr_blocks = ["0.0.0.0/0"]
 
   security_group_id = "${module.container_service_cluster.container_instance_security_group_id}"
+}
+
+resource "aws_security_group_rule" "container_instance_bastion_ssh_ingress" {
+  type      = "ingress"
+  from_port = 22
+  to_port   = 22
+  protocol  = "tcp"
+
+  security_group_id        = "${module.container_service_cluster.container_instance_security_group_id}"
+  source_security_group_id = "${module.vpc.bastion_security_group_id}"
 }

--- a/terraform/network.tf
+++ b/terraform/network.tf
@@ -1,7 +1,7 @@
 # VPC module for setting up vpc
 module "vpc" {
   source                     = "github.com/azavea/terraform-aws-vpc?ref=3.1.1"
-  name                       = "gtsite${var.environment}"
+  name                       = "vpc${var.project}${var.environment}"
   region                     = "${var.aws_region}"
   key_name                   = "${var.aws_key_name}"
   cidr_block                 = "${var.vpc_cidr_block}"

--- a/terraform/network.tf
+++ b/terraform/network.tf
@@ -1,0 +1,17 @@
+# VPC module for setting up vpc
+module "vpc" {
+  source                     = "github.com/azavea/terraform-aws-vpc?ref=3.1.1"
+  name                       = "gtsite${var.environment}"
+  region                     = "${var.aws_region}"
+  key_name                   = "${var.aws_key_name}"
+  cidr_block                 = "${var.vpc_cidr_block}"
+  external_access_cidr_block = "${var.vpc_external_access_cidr_block}"
+  private_subnet_cidr_blocks = "${var.vpc_private_subnet_cidr_blocks}"
+  public_subnet_cidr_blocks  = "${var.vpc_public_subnet_cidr_blocks}"
+  availability_zones         = "${var.vpc_availibility_zones}"
+  bastion_ami                = "${var.bastion_ami}"
+  bastion_instance_type      = "${var.vpc_bastion_instance_type}"
+
+  project     = "${var.project}"
+  environment = "${var.environment}"
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -28,7 +28,7 @@ variable "vpc_cidr_block" {
 }
 
 variable "vpc_external_access_cidr_block" {
-  default = "0.0.0.0/0"
+  default = "66.212.12.106/32"
 }
 
 variable "vpc_private_subnet_cidr_blocks" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,5 +1,5 @@
 variable "project" {
-  default = "GeoTrellis Website"
+  default = "GeoTrellis"
 }
 
 variable "environment" {
@@ -49,6 +49,14 @@ variable "bastion_ami" {
 
 variable "vpc_bastion_instance_type" {
   default = "t2.micro"
+}
+
+variable "r53_private_hosted_zone" {
+  default = "geotrellis.internal"
+}
+
+variable "r53_public_hosted_zone" {
+  default = "preview.geotrellis.io"
 }
 
 variable "container_instance_asg_desired_capacity" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -3,7 +3,7 @@ variable "project" {
 }
 
 variable "environment" {
-  default = "Staging"
+  default = "Production"
 }
 
 variable "aws_ecs_ami" {
@@ -23,14 +23,32 @@ variable "aws_elastic_load_balancing_account_id_arn" {
   default = "arn:aws:iam::127311923021:root"
 }
 
-variable "private_subnet_ids" {
-  default = [
-    "subnet-7d2ba926",
-    "subnet-f2f078df",
-  ]
+variable "vpc_cidr_block" {
+  default = "10.0.0.0/16"
+}
 
-  type        = "list"
-  description = "Private subnets for the ASG"
+variable "vpc_external_access_cidr_block" {
+  default = "0.0.0.0/0"
+}
+
+variable "vpc_private_subnet_cidr_blocks" {
+  default = ["10.0.1.0/24", "10.0.3.0/24"]
+}
+
+variable "vpc_public_subnet_cidr_blocks" {
+  default = ["10.0.0.0/24", "10.0.2.0/24"]
+}
+
+variable "vpc_availibility_zones" {
+  default = ["us-east-1a", "us-east-1c"]
+}
+
+variable "bastion_ami" {
+  default = "ami-f5f41398"
+}
+
+variable "vpc_bastion_instance_type" {
+  default = "t2.micro"
 }
 
 variable "container_instance_asg_desired_capacity" {
@@ -103,8 +121,4 @@ variable "container_instance_asg_low_memory_period_seconds" {
 
 variable "container_instance_asg_low_memory_threshold_percent" {
   default = "50"
-}
-
-variable "vpc_id" {
-  default = "vpc-617f9604"
 }


### PR DESCRIPTION
# Overview
The VPC currently used by `geotrellis-site` was created out-of-band and is not managed by Terraform. This PR codifies the addition of a new VPC by utilizing the [AWS VPC module](https://github.com/azavea/terraform-aws-vpc). I also added SSH and HTTP(s) firewall rules for the Bastion and Container instances. Finally, I created a new `preview.geotrellis.io` Route 53 Hosted zone with  a record for the Bastion instnce.

# Notes
In #12, I added some logic to `scripts/infra` to copy a `terraform.tfvars` file from S3 for planning. Since there will only be one environment for this project, the `tfvars` file is unnecessary. I undid that change in [e50f606](https://github.com/geotrellis/geotrellis-site-deployment/commit/e50f6066ca6187caac49aa2f18028b0b7ee315a3).

# Testing
- See [Travis CI](https://travis-ci.org/geotrellis/geotrellis-site-deployment/builds/233735580) logs.

- SSH into `bastion.preview.geotrellis.io`. 
    * Ensure that you can reach google.com via HTTP and HTTPs.
    * SSH into a `ContainerInstance` (10.0.1.244) and make sure HTTP(s) egress works.

Fixes #9  