### PR TITLE
Feature/tnation/asg threshold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 ansible/roles/azavea.*
 *.retry
 .ansible_galaxy
+terraform.tfstate*

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,11 +6,6 @@ Vagrant.configure("2") do |config|
     # Ubuntu 14.04 LTS
     config.vm.box = "ubuntu/trusty64"
 
-    # Ports to the services
-    config.vm.network :forwarded_port, guest: 8080, host: 8080  # nginx
-    config.vm.network :forwarded_port, guest: 9999, host: 9999  # Transit Demo
-    config.vm.network :forwarded_port, guest: 8777, host: 8777  # Chatta Demo
-
     # VM resource settings
     config.vm.provider :virtualbox do |vb|
         vb.memory = 8192

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -52,11 +52,11 @@ variable "vpc_bastion_instance_type" {
 }
 
 variable "r53_private_hosted_zone" {
-  default = "geotrellis.internal"
+  default = "geotrellis.internal."
 }
 
 variable "r53_public_hosted_zone" {
-  default = "preview.geotrellis.io"
+  default = "geotrellis.io."
 }
 
 variable "container_instance_asg_desired_capacity" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -92,7 +92,7 @@ variable "container_instance_asg_high_cpu_period_seconds" {
 }
 
 variable "container_instance_asg_high_cpu_threshold_percent" {
-  default = "75"
+  default = "100"
 }
 
 variable "container_instance_asg_low_cpu_evaluation_periods" {
@@ -104,7 +104,7 @@ variable "container_instance_asg_low_cpu_period_seconds" {
 }
 
 variable "container_instance_asg_low_cpu_threshold_percent" {
-  default = "50"
+  default = "0"
 }
 
 variable "container_instance_asg_high_memory_evaluation_periods" {
@@ -116,7 +116,7 @@ variable "container_instance_asg_high_memory_period_seconds" {
 }
 
 variable "container_instance_asg_high_memory_threshold_percent" {
-  default = "75"
+  default = "100"
 }
 
 variable "container_instance_asg_low_memory_evaluation_periods" {
@@ -128,5 +128,5 @@ variable "container_instance_asg_low_memory_period_seconds" {
 }
 
 variable "container_instance_asg_low_memory_threshold_percent" {
-  default = "50"
+  default = "0"
 }


### PR DESCRIPTION
# Overview

Adjust ASG thresholds so that Autoscaling does not as occur as a result of CPU/Memory usage. Also, stop forwarding unused ports from the Vagrant VM, and update the Route53 hosted zones (this is a deployed but uncommitted change from the DNS cutover in #10).
