### PR TITLE
Update ECS cluster to latest ECS AMI

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ $ ./scripts/setup
 Use the `infra` script to deploy the website.
 
 ```console
-export GT_SITE_SETTINGS_BUCKET="geotrellis-site-staging-config-us-east-1"
+export GT_SITE_SETTINGS_BUCKET="geotrellis-site-production-config-us-east-1"
 ./scripts/infra plan
 ./scripts/infra apply
 ```

--- a/scripts/infra
+++ b/scripts/infra
@@ -24,9 +24,6 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
     if [[ -n "${GT_SITE_SETTINGS_BUCKET}" ]]; then
         pushd "${DIR}/../terraform"
 
-        aws s3 cp "s3://${GT_SITE_SETTINGS_BUCKET}/terraform/core/terraform.tfvars" \
-            "${GT_SITE_SETTINGS_BUCKET}.tfvars"
-
         case "${1}" in
             plan)
                 rm -rf .terraform terraform.tfstate*
@@ -34,7 +31,6 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
                           -backend-config="bucket=${GT_SITE_SETTINGS_BUCKET}" \
                           -backend-config="key=terraform/core/state"
                 terraform plan \
-                          -var-file="${GT_SITE_SETTINGS_BUCKET}.tfvars" \
                           -out="${GT_SITE_SETTINGS_BUCKET}.tfplan"
                 ;;
             apply)

--- a/terraform/container_service.tf
+++ b/terraform/container_service.tf
@@ -10,13 +10,13 @@ data "template_file" "container_instance_cloud_config" {
 }
 
 module "container_service_cluster" {
-  source = "github.com/azavea/terraform-aws-ecs-cluster?ref=0.4.0"
+  source = "github.com/azavea/terraform-aws-ecs-cluster?ref=0.8.0"
 
-  vpc_id        = "${module.vpc.id}"
-  ami_id        = "${var.aws_ecs_ami}"
-  instance_type = "${var.container_instance_type}"
-  key_name      = "${var.aws_key_name}"
-  cloud_config  = "${data.template_file.container_instance_cloud_config.rendered}"
+  lookup_latest_ami = true
+  vpc_id            = "${module.vpc.id}"
+  instance_type     = "${var.container_instance_type}"
+  key_name          = "${var.aws_key_name}"
+  cloud_config      = "${data.template_file.container_instance_cloud_config.rendered}"
 
   health_check_grace_period = "600"
   desired_capacity          = "${var.container_instance_asg_desired_capacity}"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -6,10 +6,6 @@ variable "environment" {
   default = "Production"
 }
 
-variable "aws_ecs_ami" {
-  default = "ami-b2df2ca4"
-}
-
 variable "aws_key_name" {
   default = "geotrellis-site"
   type    = "string"
@@ -60,15 +56,15 @@ variable "r53_public_hosted_zone" {
 }
 
 variable "container_instance_asg_desired_capacity" {
-  default = 2
+  default = 5
 }
 
 variable "container_instance_asg_min_size" {
-  default = 2
+  default = 3
 }
 
 variable "container_instance_asg_max_size" {
-  default = 2
+  default = 5
 }
 
 variable "container_instance_type" {


### PR DESCRIPTION
Use the latest `terraform-aws-ecs-cluster` module version to automatically select the most recent ECS AMI. In the process, update documentation and remove the remote Terraform variables mechanism that wasn't being used.

---

**Testing**

From within the project virtual machine, execute the following commands:

```bash
$ export GT_SITE_SETTINGS_BUCKET="geotrellis-site-production-config-us-east-1"
$ ./scripts/infra plan
```

You should see no infrastructure changes.