### PR TITLE
Convert all instance types from T2 to T3

### DIFF
--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -44,7 +44,7 @@ variable "bastion_ami" {
 }
 
 variable "vpc_bastion_instance_type" {
-  default = "t2.nano"
+  default = "t3.nano"
 }
 
 variable "r53_private_hosted_zone" {
@@ -68,7 +68,7 @@ variable "container_instance_asg_max_size" {
 }
 
 variable "container_instance_type" {
-  default = "t2.large"
+  default = "t3.large"
 }
 
 variable "container_instance_asg_scale_up_cooldown_seconds" {


### PR DESCRIPTION
Converts all instance types in the project from T2 to T3. This includes the EC2 based ECS fleet of container instances, and the bastion.

It is also worth surfacing that the bastion conversion from T2 to T3 made it so that the EBS optimized flag for the bastion is enabled by default. To reconcile that change with the Terraform configuration, we will need to upgrade to Terraform 0.10 and then upgrade the VPC module to a version that supports supplying the EBS optimized flag.

Those two changes are covered by the two issues below. The Terraform project will be in a broken state (can't do plan/apply cycles) until those issues are resolved:

- https://github.com/geotrellis/geotrellis-site-deployment/issues/23
- https://github.com/geotrellis/geotrellis-site-deployment/issues/22

Fixes https://github.com/azavea/operations/issues/366

---

**Testing**

Navigate to the [EC2 console](https://console.aws.amazon.com/ec2/v2/home?region=us-east-1#Instances:sort=desc:launchTime) within the GeoTrellis AWS account an ensure that all EC2 instances in a `running` state are of instance type T3.