### PR TITLE
Upgrade Terraform to 0.10

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2.1"
 services:
   terraform:
-    image: quay.io/azavea/terraform:0.9.8
+    image: quay.io/azavea/terraform:0.10.8
     volumes:
       - ./:/usr/local/src
       - $HOME/.aws:/root/.aws:ro

--- a/terraform/config.tf
+++ b/terraform/config.tf
@@ -1,5 +1,10 @@
 provider "aws" {
   region = "us-east-1"
+  version = "~> 1.60.0"
+}
+
+provider "template" {
+  version = "~> 2.1.2"
 }
 
 terraform {

--- a/terraform/config.tf
+++ b/terraform/config.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  region = "us-east-1"
+  region  = "us-east-1"
   version = "~> 1.60.0"
 }
 

--- a/terraform/container_service.tf
+++ b/terraform/container_service.tf
@@ -10,7 +10,7 @@ data "template_file" "container_instance_cloud_config" {
 }
 
 module "container_service_cluster" {
-  source = "github.com/azavea/terraform-aws-ecs-cluster?ref=1.1.0"
+  source = "github.com/azavea/terraform-aws-ecs-cluster?ref=2.0.0"
 
   lookup_latest_ami    = true
   vpc_id               = "${module.vpc.id}"

--- a/terraform/container_service.tf
+++ b/terraform/container_service.tf
@@ -10,13 +10,13 @@ data "template_file" "container_instance_cloud_config" {
 }
 
 module "container_service_cluster" {
-  source = "github.com/azavea/terraform-aws-ecs-cluster?ref=0.8.0"
+  source = "github.com/azavea/terraform-aws-ecs-cluster?ref=1.1.0"
 
-  lookup_latest_ami = true
-  vpc_id            = "${module.vpc.id}"
-  instance_type     = "${var.container_instance_type}"
-  key_name          = "${var.aws_key_name}"
-  cloud_config      = "${data.template_file.container_instance_cloud_config.rendered}"
+  lookup_latest_ami    = true
+  vpc_id               = "${module.vpc.id}"
+  instance_type        = "${var.container_instance_type}"
+  key_name             = "${var.aws_key_name}"
+  cloud_config_content = "${data.template_file.container_instance_cloud_config.rendered}"
 
   health_check_grace_period = "600"
   desired_capacity          = "${var.container_instance_asg_desired_capacity}"

--- a/terraform/dns.tf
+++ b/terraform/dns.tf
@@ -3,8 +3,11 @@
 #
 resource "aws_route53_zone" "internal" {
   name       = "${var.r53_private_hosted_zone}"
-  vpc_id     = "${module.vpc.id}"
-  vpc_region = "${var.aws_region}"
+
+  vpc {
+    vpc_id     = "${module.vpc.id}"
+    vpc_region = "${var.aws_region}"
+  }
 
   tags {
     Project     = "${var.project}"

--- a/terraform/dns.tf
+++ b/terraform/dns.tf
@@ -2,7 +2,7 @@
 # Private DNS resources
 #
 resource "aws_route53_zone" "internal" {
-  name       = "${var.r53_private_hosted_zone}"
+  name = "${var.r53_private_hosted_zone}"
 
   vpc {
     vpc_id     = "${module.vpc.id}"

--- a/terraform/network.tf
+++ b/terraform/network.tf
@@ -1,16 +1,16 @@
 # VPC module for setting up vpc
 module "vpc" {
-  source                     = "github.com/azavea/terraform-aws-vpc?ref=3.1.1"
+  source                     = "github.com/azavea/terraform-aws-vpc?ref=5.0.1"
   name                       = "vpc${var.project}${var.environment}"
   region                     = "${var.aws_region}"
   key_name                   = "${var.aws_key_name}"
   cidr_block                 = "${var.vpc_cidr_block}"
-  external_access_cidr_block = "${var.vpc_external_access_cidr_block}"
   private_subnet_cidr_blocks = "${var.vpc_private_subnet_cidr_blocks}"
   public_subnet_cidr_blocks  = "${var.vpc_public_subnet_cidr_blocks}"
   availability_zones         = "${var.vpc_availibility_zones}"
   bastion_ami                = "${var.bastion_ami}"
   bastion_instance_type      = "${var.vpc_bastion_instance_type}"
+  bastion_ebs_optimized      = "${var.vpc_bastion_ebs_optimized}"
 
   project     = "${var.project}"
   environment = "${var.environment}"

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -29,7 +29,3 @@ output "container_instance_ecs_for_ec2_service_role_name" {
 output "ecs_service_role_name" {
   value = "${module.container_service_cluster.ecs_service_role_name}"
 }
-
-output "ecs_autoscale_role_arn" {
-  value = "${module.container_service_cluster.ecs_autoscale_role_arn}"
-}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -47,6 +47,10 @@ variable "vpc_bastion_instance_type" {
   default = "t3.nano"
 }
 
+variable "vpc_bastion_ebs_optimized" {
+  default = true
+}
+
 variable "r53_private_hosted_zone" {
   default = "geotrellis.internal."
 }


### PR DESCRIPTION
Upgrades Terraform to 0.10.8.

One of the major changes from 0.9 -> 0.10 is that providers are now versioned separately from Terraform. The AWS provider and template providers are now pinned to their latest compatible versions.

The [AWS VPC module](https://github.com/azavea/terraform-aws-vpc) and [AWS ECS Cluster module](https://github.com/azavea/terraform-aws-ecs-cluster) have also been upgraded to their latest compatible versions.

There are some whitespace changes present as a result of some variable names changing. I recommend hiding whitespace in the diff.

Resolves #23. 

---

**Testing**

Create a Terraform plan with `scripts/infra`:
```#bash
./scripts/infra plan
```

Confirm that the plan is created successfully and that the changes match expectations. Actions resulting from these changes will be detailed in annotations attached to the relevant code changes within this PR.